### PR TITLE
chore: add lint, prettier and test in Husky pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,5 @@
+set -e
+
+yarn lint
+yarn prettier
+yarn test --watchAll=false

--- a/README.md
+++ b/README.md
@@ -84,6 +84,17 @@ main({
 });
 ```
 
+## Husky
+
+We have Husky configured to run some hooks to execute linter, prettier and tests automatically.
+Configured hooks:
+- `pre-push`: it will run lint, prettier and tests before push.
+
+To run pre-push checks manually
+```bash
+$ sh .husky/pre-push
+```
+
 ## Building production files
 
 - Run `yarn build`

--- a/package.json
+++ b/package.json
@@ -41,14 +41,20 @@
     "typescript": "4.0.3"
   },
   "devDependencies": {
-    "firebase-tools": "^10.0.1"
+    "firebase-tools": "^10.0.1",
+    "husky": "^9.1.7"
   },
   "scripts": {
     "start": "react-scripts start",
     "build": "yarn lingui:compile && react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "lingui:compile": "yarn lingui extract && yarn lingui compile"
+    "lingui:compile": "yarn lingui extract && yarn lingui compile",
+    "lint": "eslint 'src/**/*.{js,jsx,ts,tsx}'",
+    "lint:fix": "eslint 'src/**/*.{js,jsx,ts,tsx}' --fix",
+    "prettier": "prettier --check 'src/**/*.{js,jsx,ts,tsx}'",
+    "prettier:fix": "prettier --write 'src/**/*.{js,jsx,ts,tsx}'",
+    "prepare": "husky install"
   },
   "browserslist": {
     "production": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -7374,6 +7374,11 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
+husky@^9.1.7:
+  version "9.1.7"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-9.1.7.tgz#d46a38035d101b46a70456a850ff4201344c0b2d"
+  integrity sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==
+
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"


### PR DESCRIPTION
### What

* Configure Husky `pre-push` hook

### Why

* To execute some checks (lint, prettier and tests) before pushes.
